### PR TITLE
Add support for standard history format

### DIFF
--- a/reader_test.go
+++ b/reader_test.go
@@ -23,6 +23,17 @@ func TestReader(t *testing.T) {
 				{1537448453, 0, "echo \"あいうえお\nかきくけこ\nさしすせそ\""},
 			},
 		},
+		"standard": {
+			file: "standard.histfile",
+			histories: []History{
+				{0, 0, "echo hello, world!"},
+				{0, 0, "echo hello\necho world\n"},
+				{0, 0, "go version"},
+				{0, 0, "echo こんにちは、世界"},
+				{0, 0, "echo a\nb\nc\n"},
+				{0, 0, "echo \"あいうえお\nかきくけこ\nさしすせそ\""},
+			},
+		},
 	}
 
 	for name, tt := range testCases {

--- a/testdata/standard.histfile
+++ b/testdata/standard.histfile
@@ -1,0 +1,13 @@
+echo hello, world!
+echo hello\
+echo world\
+
+go version
+echo ぃ�ゃ�にぃ�は、七�烵��
+echo a\
+b\
+c\
+
+echo "あぃ�ぃ�ぃ�ぃ�\
+ぃ�ぃ�ぃ�ぃ�ぃ�\
+ぃ�ぃ�ぃ�ぃ�ぃ�"

--- a/writer.go
+++ b/writer.go
@@ -18,26 +18,12 @@ func NewWriter(w io.Writer) *Writer {
 
 // Write a history to the writer.
 func (w *Writer) Write(h History) (err error) {
-	_, err = w.out.Write([]byte{':', ' '})
-	if err != nil {
-		return
+	if h.Time != 0 {
+		if err = w.extended(h); err != nil {
+			return err
+		}
 	}
-	_, err = w.out.Write([]byte(strconv.Itoa(h.Time)))
-	if err != nil {
-		return
-	}
-	_, err = w.out.Write([]byte{':'})
-	if err != nil {
-		return
-	}
-	_, err = w.out.Write([]byte(strconv.Itoa(h.Elapsed)))
-	if err != nil {
-		return
-	}
-	_, err = w.out.Write([]byte{';'})
-	if err != nil {
-		return
-	}
+
 	start, idx := 0, strings.IndexRune(h.Command, '\n')
 	for {
 		if idx < 0 {
@@ -59,4 +45,29 @@ func (w *Writer) Write(h History) (err error) {
 	}
 	_, err = w.out.Write([]byte{'\n'})
 	return err
+}
+
+func (w *Writer) extended(h History) (err error) {
+	_, err = w.out.Write([]byte{':', ' '})
+	if err != nil {
+		return err
+	}
+	_, err = w.out.Write([]byte(strconv.Itoa(h.Time)))
+	if err != nil {
+		return err
+	}
+	_, err = w.out.Write([]byte{':'})
+	if err != nil {
+		return err
+	}
+	_, err = w.out.Write([]byte(strconv.Itoa(h.Elapsed)))
+	if err != nil {
+		return err
+	}
+	_, err = w.out.Write([]byte{';'})
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -23,6 +23,17 @@ func TestWriter(t *testing.T) {
 				{1537448453, 0, "echo \"あいうえお\nかきくけこ\nさしすせそ\""},
 			},
 		},
+		"standard": {
+			file: "standard.histfile",
+			histories: []History{
+				{0, 0, "echo hello, world!"},
+				{0, 0, "echo hello\necho world\n"},
+				{0, 0, "go version"},
+				{0, 0, "echo こんにちは、世界"},
+				{0, 0, "echo a\nb\nc\n"},
+				{0, 0, "echo \"あいうえお\nかきくけこ\nさしすせそ\""},
+			},
+		},
 	}
 
 	for name, tt := range testCases {


### PR DESCRIPTION
The ZSH standard history format is the default history format. It is necessary to enable extended history format as part of the ZSH configuration.

Both formats can be mixed within the same history file. Identification of lines using the extended format can be found by the prefix of `: ` at the start of each command.

This change adds support for the standard history format. When reading, time and elapsed are set to `0` as this information is not available. When writing, if the time is set to `0`, a standard format line will be written which will only contain the command.

Unit tests for both the reader and writer have been added.